### PR TITLE
set "file://" prefix for project root if it doesn't have it

### DIFF
--- a/src/indexer/IndexerMain.cpp
+++ b/src/indexer/IndexerMain.cpp
@@ -125,6 +125,8 @@ int main(int argc, const char **argv) {
     SmallString<128> CurrentPath;
     sys::fs::current_path(CurrentPath);
     ProjectRoot = std::string("file://") + CurrentPath.c_str();
+  } else if (ProjectRoot.rfind("file://", 0) != 0) {
+    ProjectRoot = std::string("file://") + ProjectRoot;
   }
   if (DebugArg) {
     llvm::errs() << "Using project root " << ProjectRoot << "\n";


### PR DESCRIPTION
I was running `lsif-clang/bin/lsif-clang --project-root=$(pwd) --executor=all-TUs compile_commands.json` and it ran without error, but the generated `dump.lsif` was incorrect:

```
{"id":0,"type":"vertex","label":"metaData","version":"0.4.3","projectRoot":"/home/beyang/src/github.com/opencv/opencv","positionEncoding":"utf-16","toolInfo":{"name":"lsif-clang","version":"0.1.0"}}
{"id":1,"type":"vertex","label":"project","kind":"cpp"}
```

Not sure if this is the right fix, or if the correct behavior is just to include the `file://` prefix in the argument to the `--project-root` flag. If that's the case, it would be good to print an informative error message instead.