### PR TITLE
Fix macOS install instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -42,6 +42,8 @@ make -C build -j8  # the -j argument sets the parallelism level
 sudo make -C build install
 ```
 
+Immediately after installing, you should run `lsif-clang`. If you encounter an error like "libLLVM.dylib cannot be opened because the developer cannot be verified", open **System Preferences > Security & Privacy > General** and click **Open Anyway** next to the message "libLLVM.dylib was blocked from use because it is not from an identified developer". Run `lsif-clang` again and click the **Open** button in the system dialog that pops up.
+
 If you did not install LLVM 10 with Homebrew, you may need to modify the values of `Clang_DIR` and
 `-DPATH_TO_LLVM`. If you encounter the following error:
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,4 +1,4 @@
-# Get dependencies
+# Prerequisites
 
 This project depends on LLVM and Clang. lsif-clang itself should be built against LLVM and Clang version 10, and can index any code Clang 10 can compile.
 
@@ -19,23 +19,31 @@ don't exist in the `apt` package repository.
 ### MacOS
 
 ```sh
-brew install llvm cmake
+brew install cmake sourcegraph/brew/llvm@10
 ```
 
-# Install the tool
+> Note: lsif-clang must currently be built using LLVM 10
+
+# Installation
+
+### Ubuntu
 
 ```sh
 cmake -B build
-sudo make -C build -j16 install
+make -C build -j8  # the -j argument sets the parallelism level
+sudo make -C build install
 ```
 
-#### MacOS
-Add the following extra argument to the `cmake` step:
+### MacOS
+
 ```sh
-cmake -B build -DPATH_TO_LLVM=/usr/local/opt/lib
+Clang_DIR=/usr/local/opt/llvm\@10/lib/cmake/clang cmake -B build -DPATH_TO_LLVM=/usr/local/opt/llvm\@10
+make -C build -j8  # the -j argument sets the parallelism level
+sudo make -C build install
 ```
 
-If you encounter the following error:
+If you did not install LLVM 10 with Homebrew, you may need to modify the values of `Clang_DIR` and
+`-DPATH_TO_LLVM`. If you encounter the following error:
 
 ```
 Could not find a package configuration file provided by "Clang" with any of the following names:
@@ -47,10 +55,15 @@ Could not find a package configuration file provided by "Clang" with any of the 
 then, do the following:
 
 1. Find the path to `ClangConfig.cmake`:
+
    ```
    find /usr/ -name ClangConfig.cmake
    ```
-1. Set the *containing directory* of the first result as the value for `Clang_DIR` in the following command:
+
+1. Set the *containing directory* of the first result as the value for `Clang_DIR`. The LLVM root
+   directory is likely an ancestor of this directory; it will be the directory that contains the
+   `bin`, `include`, `lib`, and `share` subdirectories.
+
    ```
-   Clang_DIR=/path/to/containing/dir cmake -B build -DPATH_TO_LLVM=/usr/local/opt/lib
+   Clang_DIR=/path/to/containing/dir cmake -B build -DPATH_TO_LLVM=/path/to/llvm/root
    ```


### PR DESCRIPTION
The new docs use our Homebrew tap (https://github.com/sourcegraph/homebrew-brew), which contains a formula for LLVM 10 (since the main Homebrew tap currently only has versions 9 and 11). The bottles for the tap are stored in a [GCP bucket](https://github.com/sourcegraph/homebrew-brew/blob/7381dafb704c62b7bb188ba8c5e972213658313e/Formula/llvm%4010.rb#L86).