### PR TITLE
Bump dockerfile to ubuntu 20.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM ubuntu:20.04 as build
+FROM ubuntu:20.10 as build
 
-RUN apt update && apt install -y llvm-10 clang clang-10 libclang-10-dev cmake
+RUN apt update && apt install -y llvm-10 clang-10 libclang-10-dev cmake
 
 WORKDIR /lsif-clang
 
@@ -8,7 +8,7 @@ COPY . .
 
 RUN cmake -B build && make -C build -j$(nproc)
 
-FROM ubuntu:20.04
+FROM ubuntu:20.10
 
 RUN apt update && apt install -y libllvm10 cmake
 


### PR DESCRIPTION
Ubuntu 20.10 can give us clang 10.0.1 from the repos, which is the minimum requirement for torvalds/linux