### PR TITLE
Added DEBIAN_FRONTEND=noninteractive to Dockerfile and clang-10 to packages installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,10 @@ RUN CC=clang-10 CXX=clang-10 cmake -B build && make -C build -j$(nproc)
 
 FROM ubuntu:20.10
 
-RUN apt update && apt install -y libllvm10 cmake
+RUN apt update && apt install -y libllvm10 cmake clang-10
+
+# Might as well set this, for auto-index purposes
+ENV DEBIAN_FRONTEND=noninteractive
 
 COPY --from=build /lsif-clang/bin/lsif-clang /usr/local/bin/lsif-clang
 


### PR DESCRIPTION
Majority of autoindex cases required clang-10 to be installed, even though lsif-clang uses libllvm, to please cmake.
each autoindex config specifies DEBIAN_FRONTEND=noninteractive, so we might as well hardbake it into the image