### PR TITLE
Add llvm-11-dev to required packages

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -5,7 +5,7 @@ This project depends on LLVM and Clang. lsif-clang itself should be built agains
 ### Ubuntu (20.04)
 
 ```sh
-apt install llvm-11 clang clang-11 libclang-11-dev cmake binutils-dev
+apt install llvm-11 llvm-11-dev clang clang-11 libclang-11-dev cmake binutils-dev
 ```
 
 #### Older versions of Ubuntu


### PR DESCRIPTION
I found this was required to build on Ubuntu, otherwise cmake cannot find LLVMConfig.cmake.

### Test plan

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
