### PR TITLE
Add a self contained Ubuntu 18.04 based linux build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Don't copy our own file so edits to it don't cause rebuilds
+
+Dockerfile
+*.Dockerfile
+
+.dockerignore
+
+clang-tools-extra/lsif-clang/package/build.sh

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,10 @@
-# Don't copy our own file so edits to it don't cause rebuilds
+# We make our own build folder, so it doesn't need to be copied
+build
 
+# Don't copy our own files so edits to it don't cause rebuilds
+.dockerignore
 Dockerfile
 *.Dockerfile
 
-.dockerignore
-
+# This is only used outside of docker
 clang-tools-extra/lsif-clang/package/build.sh

--- a/clang-tools-extra/lsif-clang/package/build.sh
+++ b/clang-tools-extra/lsif-clang/package/build.sh
@@ -1,0 +1,58 @@
+#! /bin/bash
+
+set -euo pipefail
+
+# Configuration
+image_name="lsif-clang-$USER"
+container_name="tmp-lsif-clang-build"
+
+# Learn about our environment
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+root_dir="$script_dir/../../.."
+git_commit="$(git rev-parse HEAD)"
+
+output_filename="lsif-clang-aurora-${git_commit}"
+output_folder="${root_dir}/${output_filename}"
+archive_name="${output_filename}.tar.gz"
+
+# Cleanup our container after usage
+dockercleanup() {
+    docker rm -f "$container_name" &> /dev/null || true
+}
+
+trap dockercleanup EXIT ERR INT TERM
+dockercleanup
+
+# Build
+cd "$root_dir"
+echo "[Building image: $image_name]"
+docker build -f ubuntu_1804.Dockerfile -t "$image_name" .
+
+# Start a container with the image
+echo "[Starting temporary container: $container_name]"
+docker create --name "$container_name" "$image_name"
+
+# Get the files we need out of the image
+echo "[Extracting needed files]"
+rm -rf "$output_folder"
+mkdir "$output_folder"
+
+needed_libraries=(
+    "libclang-cpp.so.11"
+    "libLLVM-11.so.1"
+)
+
+docker cp "$container_name:/usr/local/bin/lsif-clang" "$output_folder/lsif-clang.bin"
+
+for libname in "${needed_libraries[@]}"; do
+    docker cp "$container_name:/usr/lib/x86_64-linux-gnu/$libname" "$output_folder/$libname"
+done
+
+# Install the shim in our package
+cp "$script_dir/lsif_clang_shim.sh" "$output_folder/lsif-clang"
+
+chown "$USER:$(id -g)" "$output_folder"/*
+
+# Now create our tarball
+tar zcf "${archive_name}" "$output_filename"
+echo "Created: ${archive_name}"

--- a/clang-tools-extra/lsif-clang/package/build.sh
+++ b/clang-tools-extra/lsif-clang/package/build.sh
@@ -1,5 +1,7 @@
 #! /bin/bash
 
+# Build lsif-clang in a container then extra out all the needed files.
+
 set -euo pipefail
 
 # Configuration
@@ -35,20 +37,12 @@ docker create --name "$container_name" "$image_name"
 # Get the files we need out of the image
 echo "[Extracting needed files]"
 rm -rf "$output_folder"
-mkdir "$output_folder"
+mkdir -p "$(dirname "$output_folder")"
 
-needed_libraries=(
-    "libclang-cpp.so.11"
-    "libLLVM-11.so.1"
-)
-
-docker cp "$container_name:/usr/local/bin/lsif-clang" "$output_folder/lsif-clang.bin"
-
-for libname in "${needed_libraries[@]}"; do
-    docker cp "$container_name:/usr/lib/x86_64-linux-gnu/$libname" "$output_folder/$libname"
-done
+docker cp "$container_name:/usr/local/bin" "$output_folder"
 
 # Install the shim in our package
+mv "$output_folder/lsif-clang" "$output_folder/lsif-clang.bin"
 cp "$script_dir/lsif_clang_shim.sh" "$output_folder/lsif-clang"
 
 chown "$USER:$(id -g)" "$output_folder"/*

--- a/clang-tools-extra/lsif-clang/package/copy_dependencies.sh
+++ b/clang-tools-extra/lsif-clang/package/copy_dependencies.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+    echo "usage: <binary> <output>"
+    exit 1
+fi
+
+binary="$1"
+output="$2"
+
+for lib in $(ldd "$binary" | cut -d ">" -f 2 | awk '{print $1}' | grep -vE "(linux-vdso\.|ld-linux-x86-64\.|libc\.)"); do
+    cp --verbose "$lib" "$output/"
+done

--- a/clang-tools-extra/lsif-clang/package/lsif_clang_shim.sh
+++ b/clang-tools-extra/lsif-clang/package/lsif_clang_shim.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null && pwd)"
+
+export LD_LIBRARY_PATH="$script_dir:${LD_LIBRARY_PATH:-}"
+
+exec -a "lsif-clang" "$script_dir/lsif-clang.bin" "$@"

--- a/ubuntu_1804.Dockerfile
+++ b/ubuntu_1804.Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:18.04 as build
+
+# Base tools
+RUN apt update && apt install -y ca-certificates wget gnupg2 lsb-release
+
+# LLVM Repo
+RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
+RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main" | tee -a /etc/apt/sources.list && apt-get update
+
+# CMake repo
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg > /dev/null
+RUN echo "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" | tee -a /etc/apt/sources.list && apt-get update
+
+# Install the tool chain
+RUN apt install -y llvm-11 clang-11 libclang-11-dev cmake
+
+# Do the build
+WORKDIR /lsif-clang
+
+COPY . .
+
+RUN mkdir /lsif-clang/build
+RUN cd /lsif-clang/build && CC=clang-11 CXX=clang-11 cmake .. && make -C /lsif-clang/build -j$(nproc)
+
+FROM ubuntu:18.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY --from=build /lsif-clang/bin/lsif-clang /usr/local/bin/lsif-clang
+
+# NOTE: keep in sync with build.sh
+# TODO: static build instead of copying over the libraries we need
+COPY --from=build /usr/lib/x86_64-linux-gnu/libclang-cpp.so.11 /usr/lib/x86_64-linux-gnu/libclang-cpp.so.11
+COPY --from=build /usr/lib/x86_64-linux-gnu/libLLVM-11.so.1 /usr/lib/x86_64-linux-gnu/libLLVM-11.so.1
+
+ENTRYPOINT [ "lsif-clang" ]

--- a/ubuntu_1804.Dockerfile
+++ b/ubuntu_1804.Dockerfile
@@ -21,16 +21,13 @@ COPY . .
 
 RUN mkdir /lsif-clang/build
 RUN cd /lsif-clang/build && CC=clang-11 CXX=clang-11 cmake .. && make -C /lsif-clang/build -j$(nproc)
+RUN cd /lsif-clang && clang-tools-extra/lsif-clang/package/copy_dependencies.sh ./bin/lsif-clang ./bin
 
 FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-COPY --from=build /lsif-clang/bin/lsif-clang /usr/local/bin/lsif-clang
-
-# NOTE: keep in sync with build.sh
-# TODO: static build instead of copying over the libraries we need
-COPY --from=build /usr/lib/x86_64-linux-gnu/libclang-cpp.so.11 /usr/lib/x86_64-linux-gnu/libclang-cpp.so.11
-COPY --from=build /usr/lib/x86_64-linux-gnu/libLLVM-11.so.1 /usr/lib/x86_64-linux-gnu/libLLVM-11.so.1
+# This will bring all required dependencies
+COPY --from=build /lsif-clang/bin /usr/local/bin
 
 ENTRYPOINT [ "lsif-clang" ]


### PR DESCRIPTION
This provides a self contained pre-built linux version of `lsif-clang`.  It builds
source code on Ubuntu 18.04 then copies all the shared libraries needed *except*
`libc` and the dynamic linker.  The actual binary is replaced with a shim
that places that shared library folder on the `LD_LIBRARY_PATH`.

The result is an archive that lets you run the tool on pretty much any Linux
system.

### Test plan

Build the tooling in the container:

    ./clang-tools-extra/lsif-clang/package/build.sh

Run the shim that uses the locally libraries:

```
$ ./lsif-clang-aurora-f59df9887768ff61adad5d16df98ce667db7a4dd/lsif-clang --version
LLVM (http://llvm.org/):
  LLVM version 11.1.0
  
  Optimized build.
  Default target: x86_64-pc-linux-gnu
  Host CPU: skylake-avx512
```