### PR TITLE
Add the '--jobs' flag to control max threads

### DIFF
--- a/clang-tools-extra/lsif-clang/LSIFClangMain.cpp
+++ b/clang-tools-extra/lsif-clang/LSIFClangMain.cpp
@@ -57,6 +57,11 @@ static cl::opt<bool> DebugFilesArg("debug-files",
                                    cl::desc("Debug files being processed."),
                                    cl::init(false), cl::cat(LSIFClangCategory));
 
+static cl::opt<unsigned> JobsArg("jobs",
+                            cl::desc("The number of threads to use for parallelism, 0 being a shortcut for NCPUs. Defaults to 0."),
+                            cl::init(0), cl::cat(LSIFClangCategory));
+
+
 class IndexActionFactory : public FrontendActionFactory {
 public:
   IndexActionFactory(clang::clangd::IndexFileIn &Result,
@@ -149,7 +154,8 @@ int main(int argc, const char **argv) {
   if (Compilations.getAllFiles().size() == 0) {
     exit(1);
   }
-  AllTUsToolExecutor Executor(Compilations, 0);
+
+  AllTUsToolExecutor Executor(Compilations, JobsArg);
   auto Err = Executor.execute(
       std::make_unique<IndexActionFactory>(Data, ProjectRoot), Adjuster);
   if (Err) {


### PR DESCRIPTION
This tells the executor doing the indexing the maximum number of
threads it can use instead of auto-detecting it.

Cherry-picked from https://github.com/sourcegraph/lsif-clang/pull/79

### Test plan

Manually tested.