### PR TITLE
docs: Document llvm-11-dev as required.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:22.04 as build
 
-RUN apt update && apt install -y llvm-11 clang-11 libclang-11-dev cmake libdwarf-dev libelf-dev
+RUN apt update && apt install -y llvm-11 llvm-11-dev clang-11 libclang-11-dev cmake libdwarf-dev libelf-dev
 
 WORKDIR /lsif-clang
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -5,7 +5,7 @@ This project depends on LLVM and Clang. lsif-clang itself should be built agains
 ### Ubuntu (20.04)
 
 ```sh
-apt install llvm-11 clang clang-11 libclang-11-dev cmake binutils-dev libdwarf-dev libelf-dev
+apt install llvm-11 llvm-11-dev clang-11 libclang-11-dev cmake binutils-dev libdwarf-dev libelf-dev
 ```
 
 #### Older versions of Ubuntu


### PR DESCRIPTION
llvm-11-dev provides LLVMConfig.cmake, which is required
for the build. In some situations, apt will install it
when installing llvm-11, as llvm-11-dev is recommended
by llvm-11. However, in some situations, it won't.
(It's unclear when one happens vs the other.)

So it's better to always recommend it anyways.
(cherry picked from commit 665f31b29c9bf333d40a133d7c4c25d95b056fe5)

### Test plan

Manually investigated packages and files.
See discussion in #76 