### PR TITLE
lsif-clang: Reduce contention by using per-table mutexes.

### DIFF
--- a/clang-tools-extra/clangd/indexer/IndexerMain.cpp
+++ b/clang-tools-extra/clangd/indexer/IndexerMain.cpp
@@ -55,7 +55,7 @@ public:
           }
         },
         [&](RefSlab S) {
-          std::lock_guard<std::mutex> Lock(SymbolsMu);
+          std::lock_guard<std::mutex> Lock(RefsMu);
           for (const auto &Sym : S) {
             // Deduplication happens during insertion.
             for (const auto &Ref : Sym.second)
@@ -63,7 +63,7 @@ public:
           }
         },
         [&](RelationSlab S) {
-          std::lock_guard<std::mutex> Lock(SymbolsMu);
+          std::lock_guard<std::mutex> Lock(RelationsMu);
           for (const auto &R : S) {
             Relations.insert(R);
           }
@@ -83,7 +83,9 @@ private:
   IndexFileIn &Result;
   std::mutex SymbolsMu;
   SymbolSlab::Builder Symbols;
+  std::mutex RefsMu;
   RefSlab::Builder Refs;
+  std::mutex RelationsMu;
   RelationSlab::Builder Relations;
 };
 

--- a/clang-tools-extra/lsif-clang/LSIFClangMain.cpp
+++ b/clang-tools-extra/lsif-clang/LSIFClangMain.cpp
@@ -79,6 +79,16 @@ public:
     IndexOpts.IndexMacrosInPreprocessor = true;
     IndexOpts.SystemSymbolFilter =
         clang::index::IndexingOptions::SystemSymbolFilterKind::All;
+    Opts.FileFilter = [&](const clang::SourceManager &SM, clang::FileID FID) {
+      const auto *F = SM.getFileEntryForID(FID);
+      if (!F)
+        return false; // Skip invalid files.
+      auto AbsPath = clang::clangd::getCanonicalPath(F, SM);
+      if (!AbsPath)
+        return false; // Skip files without absolute path.
+      std::lock_guard<std::mutex> Lock(FilesMu);
+      return Files.insert(*AbsPath).second; // Skip already processed files.
+    };
     return createStaticIndexingAction(
         Opts, IndexOpts,
         [&](clang::clangd::SymbolSlab S) {
@@ -118,6 +128,8 @@ public:
 
 private:
   clang::clangd::IndexFileIn &Result;
+  std::mutex FilesMu;
+  llvm::StringSet<> Files;
   std::mutex SymbolsMu;
   clang::clangd::SymbolSlab::Builder Symbols;
   std::mutex RefsMu;

--- a/clang-tools-extra/lsif-clang/LSIFClangMain.cpp
+++ b/clang-tools-extra/lsif-clang/LSIFClangMain.cpp
@@ -92,7 +92,7 @@ public:
           }
         },
         [&](clang::clangd::RefSlab S) {
-          std::lock_guard<std::mutex> Lock(SymbolsMu);
+          std::lock_guard<std::mutex> Lock(RefsMu);
           for (const auto &Sym : S) {
             // Deduplication happens during insertion.
             for (const auto &Ref : Sym.second)
@@ -100,7 +100,7 @@ public:
           }
         },
         [&](clang::clangd::RelationSlab S) {
-          std::lock_guard<std::mutex> Lock(SymbolsMu);
+          std::lock_guard<std::mutex> Lock(RelationsMu);
           for (const auto &R : S) {
             Relations.insert(R);
           }
@@ -120,7 +120,9 @@ private:
   clang::clangd::IndexFileIn &Result;
   std::mutex SymbolsMu;
   clang::clangd::SymbolSlab::Builder Symbols;
+  std::mutex RefsMu;
   clang::clangd::RefSlab::Builder Refs;
+  std::mutex RelationsMu;
   clang::clangd::RelationSlab::Builder Relations;
   std::string &ProjectRoot;
 };


### PR DESCRIPTION
For an indexing job of CMake on a 60 core machine:
- Before this change: indexing time 30s with about 31/60 core utilization
- After this change:  indexing time 25s with about 42/60 core utilization

There doesn't seem to be much effect on 16 core machines.

This was changed in upstream LLVM too (in clangd).
The code change to IndexerMain.cpp is redundant, because the code is
duplicated in LSIFClangMain.cpp, but we keep the two in sync.

### Test plan

Manually tested