### PR TITLE
docker: Re-install libdwarf-dev in next step.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN CC=clang-11 CXX=clang-11 cmake -B build && make -C build -j$(nproc)
 
 FROM ubuntu:22.04
 
-RUN apt update && apt install -y libllvm11 cmake clang-11
+RUN apt update && apt install -y libllvm11 cmake clang-11 libdwarf-dev
 
 # Might as well set this, for auto-index purposes
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
I forgot that you need to re-install stuff. Ugh.

Follow up to #80.

### Test plan

Got a linker error when trying to use the default Docker image earlier. Fixed with this.