### PR TITLE
packaging: Minor script improvements.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN CC=clang-11 CXX=clang-11 cmake -B build && make -C build -j$(nproc)
 
 FROM ubuntu:22.04
 
-RUN apt update && apt install -y libllvm11 cmake clang-11
+RUN apt update && apt install -y libllvm11 cmake clang-11 libdwarf-dev
 
 # Might as well set this, for auto-index purposes
 ENV DEBIAN_FRONTEND=noninteractive

--- a/clang-tools-extra/lsif-clang/package/build.sh
+++ b/clang-tools-extra/lsif-clang/package/build.sh
@@ -25,7 +25,7 @@ GIT_COMMIT_SHA="$(git rev-parse --short HEAD)"
 # Build
 cd "$ROOT_DIR"
 echo "[Building image: $IMAGE_NAME]"
-docker build -f Bundled_Ubuntu1804.Dockerfile -t "$IMAGE_NAME" .
+docker build -f Bundled_Ubuntu1804.Dockerfile -t "$IMAGE_NAME" . --platform linux/amd64
 
 # Start a container with the image
 echo "[Starting temporary container: $CONTAINER_NAME]"

--- a/clang-tools-extra/lsif-clang/package/copy_needed_dynamic_libs.sh
+++ b/clang-tools-extra/lsif-clang/package/copy_needed_dynamic_libs.sh
@@ -22,6 +22,9 @@ OUTPUT="$2"
 # 2. The system libraries maintained backwards compatibility.
 #    (It seems OK to roll with this assumption. We've manually
 #     verified it for Ubuntu 18.04 -> Ubuntu 20.04)
-for LIB in $(ldd "$BINARY" | cut -d ">" -f 2 | awk '{print $1}' | grep -vE "(linux-vdso\.|ld-linux-x86-64\.|libc\.|librt\.|libpthread\.)"); do
+DYN_LIBS="$(ldd "$BINARY")"
+echo "Dynamic libraries linked by lsif-clang:"
+echo "$DYN_LIBS"
+for LIB in $(echo "$DYN_LIBS" | cut -d ">" -f 2 | awk '{print $1}' | grep -vE "(linux-vdso\.|ld-linux-x86-64\.|libc\.|librt\.|libpthread\.)"); do
     cp --verbose "$LIB" "$OUTPUT/"
 done


### PR DESCRIPTION
- Use --platform linux/amd64; otherwise Docker on Mac uses aarch64 Linux.
- Print dylibs being used for debugging.

### Test plan

Manually tested.