### PR TITLE
fix typo (Github -> GitHub)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,5 +6,5 @@ contribute, and we appreciate all contributions.
 To get started with contributing, please take a look at the
 [Contributing to LLVM](https://llvm.org/docs/Contributing.html) guide. It
 describes how to get involved, raise issues and submit patches. Please note
-that at the moment the LLVM project does not use either Github pull requests
-or Github issues.
+that at the moment the LLVM project does not use either GitHub pull requests
+or GitHub issues.


### PR DESCRIPTION


[_Created by Sourcegraph batch change `sqs/github-case`._](https://sourcegraph.sourcegraph.com/users/sqs/batch-changes/github-case)